### PR TITLE
[WaRP7] PMIC swbst reg always-on

### DIFF
--- a/arch/arm/boot/dts/imx7s-warp.dts
+++ b/arch/arm/boot/dts/imx7s-warp.dts
@@ -232,6 +232,8 @@
 			swbst_reg: swbst {
 				regulator-min-microvolt = <5000000>;
 				regulator-max-microvolt = <5150000>;
+				regulator-boot-on;
+				regulator-always-on;
 			};
 
 			snvs_reg: vsnvs {


### PR DESCRIPTION
This patch allows to activate SWBTS (PMIC regulator) at 5V (due to Mikrobus power supply).

Tested on Yocto/OE (krogoth branch) with the linux-warp7 kernel.

Signed-off-by: Alan <aitali.alan@gmail.com>