### PR TITLE
[WaRP7] Fix the build error (proper indentation)

### DIFF
--- a/drivers/mxc/gpu-viv/hal/os/linux/kernel/platform/freescale/gc_hal_kernel_platform_imx6q14.c
+++ b/drivers/mxc/gpu-viv/hal/os/linux/kernel/platform/freescale/gc_hal_kernel_platform_imx6q14.c
@@ -475,8 +475,8 @@ gckPLATFORM_AdjustParam(
 
     Args->gpu3DMinClock = initgpu3DMinClock;
 
-  if(Args->physSize == 0)
-    Args->physSize = 0x80000000;
+    if(Args->physSize == 0)
+	Args->physSize = 0x80000000;
 
     return gcvSTATUS_OK;
 }


### PR DESCRIPTION
- With GCC > 6, the build is broken. This patch avoid the following issue

drivers/mxc/gpu-viv/hal/os/linux/kernel/platform/freescale/gc_hal_kernel_platform_imx6q14.c:478:3: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>